### PR TITLE
feat: skip unrecognizable commits

### DIFF
--- a/lib/conventional_changelog/git.rb
+++ b/lib/conventional_changelog/git.rb
@@ -5,8 +5,9 @@ module ConventionalChangelog
     def self.commits(options)
       log(options).split("\n").map { |commit| commit.split DELIMITER }.select { |commit| options[:since_date].nil? or commit[1] > options[:since_date] }.map do |commit|
         comment = commit[2].match(/(\w*)(\(([\w\$\.\-\* ]*)\))?\: (.*)/)
+        next unless comment
         { id: commit[0], date: commit[1], type: comment[1], component: comment[3], change: comment[4] }
-      end
+      end.compact
     end
 
     def self.log(options)

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -25,6 +25,38 @@ describe ConventionalChangelog::Generator do
       end
     end
 
+    context "with merge commit" do
+      before :each do
+        allow(ConventionalChangelog::Git).to receive(:log).and_return log
+      end
+
+      context "skip merged commit" do
+        let(:log) do <<-LOG
+4303fd4/////2015-03-30/////feat(admin): increase reports ranges
+430fa51/////2015-03-31/////Merge branch 'develop' into 'master'
+          LOG
+        end
+
+        it 'does not contain merge commit' do
+          subject.generate!
+          body = <<-BODY
+<a name="2015-03-30"></a>
+### 2015-03-30
+
+
+#### Features
+
+* **admin**
+  * increase reports ranges ([4303fd4](/../../commit/4303fd4))
+
+
+
+          BODY
+          expect(changelog).to eql body
+        end
+      end
+    end
+
     context "with multiple commits" do
       before :each do
         allow(ConventionalChangelog::Git).to receive(:log).and_return log


### PR DESCRIPTION
skip unrecognizable commits, previously merge commits or commits that don't follow the message format caused an exception. 
