### PR TITLE
Improve error handling

### DIFF
--- a/lib/conventional_changelog/git.rb
+++ b/lib/conventional_changelog/git.rb
@@ -1,3 +1,5 @@
+require 'open3'
+
 module ConventionalChangelog
   class Git
     DELIMITER = "/////"
@@ -11,7 +13,18 @@ module ConventionalChangelog
     end
 
     def self.log(options)
-      `git log --pretty=format:"%h#{DELIMITER}%ad#{DELIMITER}%s%x09" --date=short --grep="^(feat|fix)(\\(.*\\))?:" -E #{version_filter(options)}`
+      output, status = Open3.capture2(%Q{
+        git log \
+          --pretty=format:"%h#{DELIMITER}%ad#{DELIMITER}%s%x09" --date=short \
+          --grep="^(feat|fix)(\\(.*\\))?:" -E \
+          #{version_filter(options)}
+      })
+
+      if status.success?
+        output
+      else
+        raise "Can't load Git commits, check your arguments"
+      end
     end
 
     def self.version_filter(options)

--- a/lib/conventional_changelog/writer.rb
+++ b/lib/conventional_changelog/writer.rb
@@ -1,13 +1,16 @@
 module ConventionalChangelog
   class Writer < File
     def initialize(file_name)
-      @previous_body = File.open(file_name, "a+").read
-      super file_name, "w"
+      FileUtils.touch file_name
+      super file_name, 'r+'
+
+      @previous_body = read
     end
 
     def write!(options)
+      seek 0
       write_new_lines options
-      self.puts @previous_body
+      puts @previous_body
     end
 
     private

--- a/lib/conventional_changelog/writer.rb
+++ b/lib/conventional_changelog/writer.rb
@@ -42,6 +42,8 @@ module ConventionalChangelog
     end
 
     def write_section(commits, id)
+      return if commits.empty?
+
       puts version_header(id)
       append_changes commits, "feat", "Features"
       append_changes commits, "fix", "Bug Fixes"

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -229,5 +229,14 @@ describe ConventionalChangelog::Generator do
       end
 
     end
+
+    context "with unexpected errors" do
+      it "keeps the original changelog" do
+        File.write("CHANGELOG.md", "original")
+        expect { subject.generate! }.to raise_exception NoMethodError
+
+        expect(changelog).to eql "original"
+      end
+    end
   end
 end

--- a/spec/git_spec.rb
+++ b/spec/git_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe ConventionalChangelog::Git do
+  subject { ConventionalChangelog::Git }
+
+  describe ".log" do
+    it "returns a log with default options" do
+      log = subject.log({})
+
+      expect(log).to include "feat(bin): add a conventional-changelog binary"
+    end
+
+    it "raises an exception if Git returns an error" do
+      expect do
+        subject.log({ since_version: 'invalid-branch' })
+      end.to raise_exception RuntimeError, "Can't load Git commits, check your arguments"
+    end
+  end
+end


### PR DESCRIPTION
This fixes some problems I ran into:
- exceptions because of invalid version arguments / empty Git log
- empty `CHANGELOG.md` file because of exceptions
