### PR TITLE
fix: Allow last release id to be specified manually

### DIFF
--- a/conventional-changelog.gemspec
+++ b/conventional-changelog.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", ">= 3.2"
   spec.add_development_dependency "fakefs"
-  spec.add_development_dependency "codeclimate-test-reporter"
+  spec.add_development_dependency "codeclimate-test-reporter", "~> 0.1"
 end


### PR DESCRIPTION
When the existing CHANGELOG is not in the conventional format and the ID of the previous
release cannot be determined, allow the user to specify the ID manually by setting the
CONVENTIONAL_CHANGELOG_LAST_RELEASE environment variable.

Closes #6