### PR TITLE
Feat/maintain changelog on error

### DIFF
--- a/lib/conventional_changelog/by_date_writer.rb
+++ b/lib/conventional_changelog/by_date_writer.rb
@@ -6,7 +6,7 @@ module ConventionalChangelog
       :since_date
     end
 
-    def write_new_lines(options)
+    def build_new_lines(options)
       commits.group_by { |commit| commit[:date] }.sort.reverse_each do |date, commits|
         write_section commits, date
       end

--- a/lib/conventional_changelog/by_version_writer.rb
+++ b/lib/conventional_changelog/by_version_writer.rb
@@ -6,7 +6,7 @@ module ConventionalChangelog
       :since_version
     end
 
-    def write_new_lines(options)
+    def build_new_lines(options)
       write_section commits, options[:version]
     end
 

--- a/lib/conventional_changelog/writer.rb
+++ b/lib/conventional_changelog/writer.rb
@@ -24,7 +24,7 @@ and running the generate command again.
     def write!(options)
       seek 0
       write_new_lines options
-      puts @previous_body
+      write @previous_body
     end
 
     private

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -21,7 +21,7 @@ describe ConventionalChangelog::Generator do
 
       it 'creates an empty changelog when no commits' do
         subject.generate!
-        expect(changelog).to eql "\n"
+        expect(changelog).to eql ""
       end
     end
 
@@ -48,7 +48,6 @@ describe ConventionalChangelog::Generator do
 
 * **admin**
   * increase reports ranges ([4303fd4](/../../commit/4303fd4))
-
 
 
           BODY
@@ -104,7 +103,6 @@ describe ConventionalChangelog::Generator do
 
 * **admin**
   * add page to manage users ([4303fd8](/../../commit/4303fd8))
-
 
 
           BODY
@@ -220,7 +218,6 @@ describe ConventionalChangelog::Generator do
 #### Bug Fixes
 
 * fix annoying bug ([4303fd5](/../../commit/4303fd5))
-
 
 
           BODY

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -250,5 +250,17 @@ describe ConventionalChangelog::Generator do
         end
       end
     end
+
+    context "when an error occurs generating the commit log" do
+      before do
+        allow_any_instance_of(ConventionalChangelog::Writer).to receive(:append_changes).and_raise("an error")
+      end
+
+      it "maintains the original content" do
+        File.write("CHANGELOG.md", '<a name="v1.0.0"></a>')
+        expect { subject.generate! version: "v2.0.0" }.to raise_error(RuntimeError)
+        expect(File.read("CHANGELOG.md")).to eq '<a name="v1.0.0"></a>'
+      end
+    end
   end
 end


### PR DESCRIPTION
When there is an error generating the new changelog, ensure the original content of the file
does not get wiped.