### PR TITLE
feat: remove triple new lines in generated output

### DIFF
--- a/lib/conventional_changelog/writer.rb
+++ b/lib/conventional_changelog/writer.rb
@@ -38,7 +38,6 @@ and running the generate command again.
 <a name="#{id}"></a>
 ### #{version_header_title(id)}
 
-
       HEADER
     end
 
@@ -54,7 +53,6 @@ and running the generate command again.
           component_commits.each { |commit| write_commit commit, component }
           @new_body.puts ""
         end
-        @new_body.puts ""
       end
     end
 

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -43,12 +43,10 @@ describe ConventionalChangelog::Generator do
 <a name="2015-03-30"></a>
 ### 2015-03-30
 
-
 #### Features
 
 * **admin**
   * increase reports ranges ([4303fd4](/../../commit/4303fd4))
-
 
           BODY
           expect(changelog).to eql body
@@ -78,22 +76,18 @@ describe ConventionalChangelog::Generator do
 <a name="2015-03-30"></a>
 ### 2015-03-30
 
-
 #### Features
 
 * **admin**
   * increase reports ranges ([4303fd4](/../../commit/4303fd4))
-
 
 #### Bug Fixes
 
 * **api**
   * fix annoying bug ([4303fd5](/../../commit/4303fd5))
 
-
 <a name="2015-03-28"></a>
 ### 2015-03-28
-
 
 #### Features
 
@@ -104,7 +98,6 @@ describe ConventionalChangelog::Generator do
 * **admin**
   * add page to manage users ([4303fd8](/../../commit/4303fd8))
 
-
           BODY
           expect(changelog).to eql body
         end
@@ -113,7 +106,6 @@ describe ConventionalChangelog::Generator do
           previous_body = <<-BODY
 <a name="2015-03-28"></a>
 ### 2015-03-28
-
 
 #### Features
 
@@ -129,18 +121,15 @@ describe ConventionalChangelog::Generator do
 <a name="2015-03-30"></a>
 ### 2015-03-30
 
-
 #### Features
 
 * **admin**
   * increase reports ranges ([4303fd4](/../../commit/4303fd4))
 
-
 #### Bug Fixes
 
 * **api**
   * fix annoying bug ([4303fd5](/../../commit/4303fd5))
-
 
 #{previous_body}
           BODY
@@ -161,7 +150,6 @@ describe ConventionalChangelog::Generator do
 <a name="0.1.0"></a>
 ### 0.1.0 (2015-03-28)
 
-
 #### Features
 
 * **api**
@@ -176,18 +164,15 @@ describe ConventionalChangelog::Generator do
 <a name="0.2.0"></a>
 ### 0.2.0 (2015-03-30)
 
-
 #### Features
 
 * **admin**
   * increase reports ranges ([4303fd4](/../../commit/4303fd4))
 
-
 #### Bug Fixes
 
 * **api**
   * fix annoying bug ([4303fd5](/../../commit/4303fd5))
-
 
 #{previous_body}
           BODY
@@ -209,16 +194,13 @@ describe ConventionalChangelog::Generator do
 <a name="2015-03-30"></a>
 ### 2015-03-30
 
-
 #### Features
 
 * increase reports ranges ([4303fd4](/../../commit/4303fd4))
 
-
 #### Bug Fixes
 
 * fix annoying bug ([4303fd5](/../../commit/4303fd5))
-
 
           BODY
           expect(changelog).to eql body


### PR DESCRIPTION
I understand this is a very subjective thing, but I've been going through and deleting the third new line from all my generated change logs manually, so I wondered if you would consider making it a change in the gem.

As an example, it changes this:
```
<a name="v1.13.0"></a>
### v1.13.0 (2017-10-28)


#### Features

* **gems**
  * update to pact-mock_service 2.5.1	 ([1b0ed8b](/../../commit/1b0ed8b))


```

into this:

```
<a name="v1.13.0"></a>
### v1.13.0 (2017-10-28)

#### Features

* **gems**
  * update to pact-mock_service 2.5.1	 ([1b0ed8b](/../../commit/1b0ed8b))

```

I tried just doing a gsub in the code after generating it, but the way the Writer is constructed, opening the file with r+ in the constructor seems to lock the file somehow. I can't reproduce it in the tests however. If you're not keen on making this change, I might do a PR to fix the locking problem instead.