### PR TITLE
feat: support release notes generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ into this:
     * **admin**
       * add page to manage users (4303fd8)
 
+## Options
+
+* `version_headers`: prepend the commits with the version header(s). Default: `true`.
+* `anchors`: prepend the version headers with anchor tags. Default: `true`.
+* `force`: write a heading even if there are no commits found. Default: `false`.
+* `dry_run`: write the output to stdout rather than updating the CHANGELOG.md file. Useful for generating release notes. Default: `false`.
+
 ## Contributing
 
 1. Fork it ( https://github.com/dcrec1/conventional-changelog-ruby/fork )

--- a/lib/conventional_changelog/by_date_writer.rb
+++ b/lib/conventional_changelog/by_date_writer.rb
@@ -1,3 +1,5 @@
+require 'date'
+
 module ConventionalChangelog
   class ByDateWriter < Writer
     private
@@ -7,8 +9,16 @@ module ConventionalChangelog
     end
 
     def build_new_lines(options)
-      commits.group_by { |commit| commit[:date] }.sort.reverse_each do |date, commits|
-        write_section commits, date
+      if commits.any?
+        if options[:version_headers]
+          commits.group_by { |commit| commit[:date] }.sort.reverse_each do |date, commits|
+            write_section commits, date, options
+          end
+        else
+          write_section commits, commits[0][:date], options
+        end
+      elsif options[:force]
+        write_section commits, Date.today.strftime("%Y-%m-%d"), options
       end
     end
 

--- a/lib/conventional_changelog/by_version_writer.rb
+++ b/lib/conventional_changelog/by_version_writer.rb
@@ -1,3 +1,5 @@
+require 'date'
+
 module ConventionalChangelog
   class ByVersionWriter < Writer
     private
@@ -7,11 +9,14 @@ module ConventionalChangelog
     end
 
     def build_new_lines(options)
-      write_section commits, options[:version]
+      if commits.any? || options[:force]
+        write_section commits, options[:version], options
+      end
     end
 
     def version_header_title(id)
-      "#{id} (#{commits[0][:date]})"
+      date = commits.any? ? commits[0][:date] : Date.today.strftime("%Y-%m-%d")
+      "#{id} (#{date})"
     end
   end
 end

--- a/lib/conventional_changelog/cli.rb
+++ b/lib/conventional_changelog/cli.rb
@@ -5,7 +5,15 @@ module ConventionalChangelog
     end
 
     def self.parse(params)
-      Hash[*params.map { |param| param.split("=") }.map { |key, value| [key.to_sym, value] }.flatten]
+      Hash[*params.map { |param| param.split("=") }.map { |key, value| [key.to_sym, parse_value(value)] }.flatten]
+    end
+
+    def self.parse_value(value)
+      case value
+      when 'true' then true
+      when 'false' then false
+      else value
+      end
     end
   end
 end

--- a/lib/conventional_changelog/generator.rb
+++ b/lib/conventional_changelog/generator.rb
@@ -1,7 +1,14 @@
 module ConventionalChangelog
   class Generator
+    DEFAULT_OPTIONS = {
+      version_headers: true,
+      anchors: true,
+      dry_run: false,
+      force: false
+    }.freeze
+
     def generate!(options = {})
-      writer(options).new("CHANGELOG.md").write! options
+      writer(options).new("CHANGELOG.md").write!(DEFAULT_OPTIONS.merge(options))
     end
 
     private

--- a/lib/conventional_changelog/writer.rb
+++ b/lib/conventional_changelog/writer.rb
@@ -26,9 +26,14 @@ and running the generate command again.
 
     def write!(options)
       build_new_lines options
-      seek 0
-      write @new_body.string
-      write @previous_body
+      if options[:dry_run]
+        $stdout.puts(@new_body.string)
+        @new_body.string
+      else
+        seek 0
+        write @new_body.string
+        write @previous_body
+      end
     end
 
     private

--- a/lib/conventional_changelog/writer.rb
+++ b/lib/conventional_changelog/writer.rb
@@ -27,8 +27,8 @@ and running the generate command again.
     def write!(options)
       build_new_lines options
       if options[:dry_run]
-        $stdout.puts(@new_body.string)
-        @new_body.string
+        $stdout.puts(@new_body.string.strip)
+        @new_body.string.strip
       else
         seek 0
         write @new_body.string
@@ -38,10 +38,10 @@ and running the generate command again.
 
     private
 
-    def version_header(id)
+    def version_header(id, options)
+      anchor = options[:anchors] ? "<a name=\"#{id}\"></a>\n" : ""
       <<-HEADER
-<a name="#{id}"></a>
-### #{version_header_title(id)}
+#{anchor}### #{version_header_title(id)}
 
       HEADER
     end
@@ -65,12 +65,15 @@ and running the generate command again.
       @new_body.puts "#{componentized ? '  ' : ''}* #{commit[:change]} ([#{commit[:id]}](/../../commit/#{commit[:id]}))"
     end
 
-    def write_section(commits, id)
-      return if commits.empty?
+    def write_section(commits, id, options)
+      if options[:version_headers]
+        @new_body.puts version_header(id, options)
+      end
 
-      @new_body.puts version_header(id)
-      append_changes commits, "feat", "Features"
-      append_changes commits, "fix", "Bug Fixes"
+      if commits.any?
+        append_changes commits, "feat", "Features"
+        append_changes commits, "fix", "Bug Fixes"
+      end
     end
 
     def last_id

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -266,10 +266,16 @@ describe ConventionalChangelog::Generator do
       end
     end
 
-    context "with dry_run == true" do
+    context "with dry_run: true" do
       before do
         File.write("CHANGELOG.md", '<a name="v1.0.0"></a>')
         allow($stdout).to receive(:puts)
+        allow(ConventionalChangelog::Git).to receive(:log).and_return log
+      end
+
+      let(:log) do <<-LOG
+4303fd4/////2015-03-30/////feat(foo): something
+        LOG
       end
 
       let(:generate) { subject.generate!(version: "v2.0.0", dry_run: true) }

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -244,5 +244,23 @@ describe ConventionalChangelog::Generator do
         expect(File.read("CHANGELOG.md")).to eq '<a name="v1.0.0"></a>'
       end
     end
+
+    context "with dry_run == true" do
+      before do
+        File.write("CHANGELOG.md", '<a name="v1.0.0"></a>')
+        allow($stdout).to receive(:puts)
+      end
+
+      let(:generate) { subject.generate!(version: "v2.0.0", dry_run: true) }
+
+      it "maintains the original content" do
+        expect { generate }.to_not change { File.read("CHANGELOG.md") }
+      end
+
+      it "prints the contents to stdout" do
+        expect($stdout).to receive(:puts).with(/#### Features/)
+        generate
+      end
+    end
   end
 end

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -19,9 +19,30 @@ describe ConventionalChangelog::Generator do
         allow(ConventionalChangelog::Git).to receive(:log).and_return ""
       end
 
-      it 'creates an empty changelog when no commits' do
-        subject.generate!
-        expect(changelog).to eql ""
+      context "when force is not true" do
+        it "creates an empty changelog when a version is set" do
+          subject.generate!(version: "0.2.0")
+          expect(changelog).to eql ""
+        end
+
+        it "creates an empty changelog when a version is not set" do
+          subject.generate!
+          expect(changelog).to eql ""
+        end
+      end
+
+      context "when force is true" do
+        let(:today) { Date.today.strftime("%Y-%m-%d") }
+
+        it "creates an empty changelog with a heading with today's date when a version is set" do
+          subject.generate!(version: "0.2.0", force: true)
+          expect(changelog).to eql "<a name=\"0.2.0\"></a>\n### 0.2.0 (#{today})\n\n"
+        end
+
+        it "creates an empty changelog with a heading with today's date when a version is not set" do
+          subject.generate!(force: true)
+          expect(changelog).to eql "<a name=\"#{today}\"></a>\n### #{today}\n\n"
+        end
       end
     end
 
@@ -260,6 +281,55 @@ describe ConventionalChangelog::Generator do
       it "prints the contents to stdout" do
         expect($stdout).to receive(:puts).with(/#### Features/)
         generate
+      end
+
+    end
+
+    context "with version_headers: false" do
+      before do
+        allow($stdout).to receive(:puts)
+      end
+
+      context "with a version" do
+        let(:generate) { subject.generate!(version: "v2.0.0", dry_run: true, version_headers: false) }
+
+        it "does not include the version headings with a version" do
+          expect(generate).to start_with "#### Features"
+          expect(generate.scan(/#### Features/).count).to eq 1
+          expect(generate.scan(/#### Bug Fixes/).count).to eq 1
+        end
+      end
+
+      context "without a version" do
+        let(:generate) { subject.generate!(dry_run: true, version_headers: false) }
+
+        it "does not include the version headings with a version and does not group the commits" do
+          expect(generate).to start_with "#### Features"
+          expect(generate.scan(/#### Features/).count).to eq 1
+          expect(generate.scan(/#### Bug Fixes/).count).to eq 1
+        end
+      end
+    end
+
+    context "with anchors: false" do
+      before do
+        allow($stdout).to receive(:puts)
+      end
+
+      context "with a version" do
+        let(:generate) { subject.generate!(version: "v2.0.0", dry_run: true, anchors: false) }
+
+        it "does not include the anchors" do
+          expect(generate).to_not include "<a name"
+        end
+      end
+
+      context "without a version" do
+        let(:generate) { subject.generate!(dry_run: true, anchors: false) }
+
+        it "does not include the version headings with a version and does not group the commits" do
+          expect(generate).to_not include "<a name"
+        end
       end
     end
   end


### PR DESCRIPTION
I'm currently using some dirty [grep and sed](https://github.com/pact-foundation/release-gem/blob/v0.0.10/container/usr/local/bin/create-github-release#L10) to extract the release notes from the updated changelog. These options allow the content to be created cleanly.
